### PR TITLE
Spike athlete show

### DIFF
--- a/app/controllers/athletes_controller.rb
+++ b/app/controllers/athletes_controller.rb
@@ -27,6 +27,16 @@ class AthletesController < ApplicationController
     @athlete = Athlete.find(params[:id])
   end
 
+  def edit
+    @athlete = Athlete.find(params[:id])
+  end
+
+  def update
+    @athlete = Athlete.find(params[:id])
+    @athlete = Athlete.update(athlete_params)
+    redirect_to athlete_path(@athlete)
+  end
+
   private
   def athlete_params
     params.require(:athlete).permit(:name, :gender, :feet, :inches, :weight, :birthday)

--- a/app/views/athletes/edit.html.erb
+++ b/app/views/athletes/edit.html.erb
@@ -1,0 +1,22 @@
+<h1> <%= @athlete.name %> </h1>
+
+<%= form_with model: @athlete, method: :patch, local: true do |form|%>
+  <%= form.label :name %>
+  <%= form.text_field :name %><br>
+
+  <%= form.label :gender %>
+  <%= form.select :gender, ["Male", "Female", "Unspecified"] %><br>
+
+  HEIGHT: <%= form.label :feet %>
+  <%= form.number_field :feet %>
+  <%= form.label :inches %>
+  <%= form.number_field :inches %><br>
+
+  <%= form.label :weight %>
+  <%= form.number_field :weight %><br>
+
+  <%= form.label :birthday%>
+  <%= form.date_field :birthday %><br>
+
+  <%= form.submit "Update #{@athlete.name}" %>
+  <% end %>

--- a/app/views/athletes/index.html.erb
+++ b/app/views/athletes/index.html.erb
@@ -2,10 +2,12 @@
 
 <% @athletes.each do |athlete| %>
 <div id=<%="athlete-#{athlete.id}" %>>
-  <h3><%= athlete.name %></h3>
+<h3><%= link_to "#{athlete.name}", athlete_path(athlete) %></h3>
   Gender: <%= athlete.gender %><br>
   Height: <%= athlete.feet %>'<%= athlete.inches %>"<br>
   Weight: <%= athlete.weight %>lbs<br>
   Birthday: <%= athlete.birthday.strftime("%-m/%-d/%Y") %><br>
+  <%= link_to "Edit ", edit_athlete_path(athlete) %><br>
+
 </div>
 <% end %>

--- a/app/views/athletes/new.html.erb
+++ b/app/views/athletes/new.html.erb
@@ -1,6 +1,7 @@
 <h1> Create Your Account </h1>
 
-<%= form_with model: @new_athlete, local: true do |form| %>  <%= form.label :name, 'NAME:' %>
+<%= form_with model: @new_athlete, local: true do |form| %> 
+  <%= form.label :name, 'NAME:' %>
   <%= form.text_field :name %><br>
 
   <%= form.label :gender, 'GENDER:' %>

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -2,7 +2,7 @@
 Gender: <%= @athlete.gender %><br>
 Height: <%= @athlete.feet %>'<%= @athlete.inches %>"<br>
 Weight: <%= @athlete.weight %>lbs<br>
-Birthday: <%= @athlete.birthday.strftime("%-m/%-d/%Y")%><br>
+Birthday: <%= @athlete.birthday.strftime("%-m/%-d/%Y")%>
 <br>
 <%= link_to "Edit", edit_athlete_path(@athlete) %>
 <h3> Movements </h3>

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -1,1 +1,12 @@
 <h1> <%= @athlete.name %> </h1>
+Gender: <%= @athlete.gender %><br>
+Height: <%= @athlete.feet %>'<%= @athlete.inches %>"<br>
+Weight: <%= @athlete.weight %>lbs<br>
+Birthday: <%= @athlete.birthday.strftime("%-m/%-d/%Y")%><br>
+<br>
+<%= link_to "Edit", edit_athlete_path(@athlete) %>
+<h3> Movements </h3>
+
+<h3> Goals </h3>
+
+<%= link_to "Progress", athlete_path(@athlete) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
   root "welcome#index"
   resources :users, only: [:new, :create]
 
-  resources :athletes, only: [:index, :new, :create, :show]
+  resources :athletes, only: [:index, :new, :create, :show, :edit, :update] do
+    resources :progresses, only: [:index]
+  end
 
   get "/login", to: "users#login_form"
   post "/login", to: "users#login"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,5 +11,5 @@
 
 
 @user = User.create!(username: "Dana Howell", email: "howelld115@gmail.com", password: "test")
-@dana = @user.athletes.create!(name: "Dana Howell", gender: "Female", height: 67, weight: 155, birthday: "1982-08-22") ##in pry: Sun, 22 Aug 1982
-@stace = @user.athletes.create!(name: "Stacey Kessler", gender: "Female", height: 70, weight: 175, birthday: "1987-09-06")
+@dana = @user.athletes.create!(name: "Dana Howell", gender: "Female", feet: 5, inches: 7, weight: 155, birthday: "1982-08-22") ##in pry: Sun, 22 Aug 1982
+@stace = @user.athletes.create!(name: "Stacey Kessler", gender: "Female", feet: 5, inches: 10, weight: 175, birthday: "1987-09-06")

--- a/docs/user_stories.md
+++ b/docs/user_stories.md
@@ -64,7 +64,7 @@
     - Birthday: date
   - When I click "Save" I am redirected to athlete_path(@athlete)
 
-> ## DASHBOARD
+> ## DASHBOARD/SHOW
 - I can really see the dashboard wrapping everything together and making the information really nice! (Can save it for after all the other pages are made)
 - US User Dashboard
   - as a user,

--- a/spec/features/athletes/athlete_edit_spec.rb
+++ b/spec/features/athletes/athlete_edit_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'edit athlete', type: :feature do
+  describe ' USER STORY #' do
+    describe ' as a user/admin when I visit edit_athlete_path' do
+      before(:each) do
+        @user = User.create!(username: "Dana Howell", email: "howelld115@gmail.com", password: "test")
+
+        @stace = @user.athletes.create!(name: "Stacey Kessler", gender: "Female", feet: 5, inches: 10, weight: 175, birthday: "1987-09-06")
+        visit edit_athlete_path(@stace)
+      end
+      it 'displays' do
+        visit athlete_path(@stace)
+        expect(page).to have_content("Weight: 175")
+
+        click_link "Edit"
+        expect(current_path).to eq(edit_athlete_path(@stace))
+        
+        expect(page).to have_field("Name", with: @stace.name)
+        expect(page).to have_select("Gender", selected: @stace.gender)
+        expect(page).to have_field("Feet", with: @stace.feet)
+        expect(page).to have_field("Inches", with: @stace.inches)
+        expect(page).to have_field("Weight", with: @stace.weight)
+        expect(page).to have_field("Birthday", with: @stace.birthday)
+
+        fill_in 'Weight', with: 179
+
+        click_button "Update #{@stace.name}"
+        expect(current_path).to eq(athlete_path(@stace))
+        expect(page).to have_content("Weight: 179")
+      end
+    end 
+  end
+end

--- a/spec/features/athletes/athlete_index_spec.rb
+++ b/spec/features/athletes/athlete_index_spec.rb
@@ -8,30 +8,10 @@ RSpec.describe "new_athlete", type: :feature  do
       @stace = @user.athletes.create!(name: "Stacey Kessler", gender: "Female", feet: 5, inches: 10, weight: 175, birthday: "1987-09-06")
 
       visit athletes_path
-      # @user.athletes << [@dana, @stace]
     end
 
     it "displays all athletes with attributes" do
-      # visit new_athlete_path
-      
-      # fill_in("Name", with: @dana.name)
-      # fill_in("Gender", with: @dana.gender)
-      # fill_in("Height", with: @dana.height)
-      # fill_in("Weight", with: @dana.weight)
-      # fill_in("Birthday", with: @dana.birthday)
-
-      # fill_in("Name", with: @stace.name)
-      # fill_in("Gender", with: @stace.gender)
-      # fill_in("Feet", with: @stace.feet)
-      # fill_in("Inches", with: @stace.inches)
-      # fill_in("Weight", with: @stace.weight)
-      # fill_in("Birthday", with: @stace.birthday)
-      
-      # click_button("Create Athlete")
-      # expect(current_path).to eq(athletes_path)
       within "#athlete-#{@dana.id}" do
-      save_and_open_page
-      
         expect(page).to have_content(@dana.name)
         expect(page).to have_content(@dana.gender)
         expect(page).to have_content(@dana.feet)
@@ -46,6 +26,22 @@ RSpec.describe "new_athlete", type: :feature  do
         expect(page).to have_content(@stace.inches)
         expect(page).to have_content(@stace.weight)
         expect(page).to have_content(@stace.birthday.strftime("%-m/%-d/%Y"))
+      end
+    end
+
+    it "has a link to edit athlete" do
+      within "#athlete-#{@stace.id}" do
+        expect(page).to have_link("Edit")
+        click_on "Edit"
+        expect(current_path).to eq(edit_athlete_path(@stace))
+      end
+    end
+
+    it "has a link to athlete's show page" do
+      within "#athlete-#{@stace.id}" do
+        expect(page).to have_link("#{@stace.name}")
+        click_on "#{@stace.name}"
+        expect(current_path).to eq(athlete_path(@stace))
       end
     end
   end

--- a/spec/features/athletes/athlete_show_spec.rb
+++ b/spec/features/athletes/athlete_show_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'Athlete Show', type: :feature do
+  describe ' as a user/admin when I visit /path' do
+    before(:each) do
+      @user = User.create!(username: "Dana Howell", email: "howelld115@gmail.com", password: "test")
+
+      @stace = @user.athletes.create!(name: "Stacey Kessler", gender: "Female", feet: 5, inches: 10, weight: 175, birthday: "1987-09-06")
+      visit athlete_path(@stace)
+    end
+
+    it 'displays athlete name and movements' do
+      expect(page).to have_content(@stace.name)
+      expect(page).to have_content("Height: 5'10")
+      expect(page).to have_content(@stace.weight)
+      expect(page).to have_content(@stace.birthday.strftime("%-m/%-d/%Y"))
+      expect(page).to have_link("Progress")
+    end
+
+    it "has a link to edit athlete" do
+      expect(page).to have_link("Edit")
+  
+      click_link "Edit"
+  
+      expect(current_path).to eq(edit_athlete_path(@stace))
+    end
+
+    it "has a link to Progress" do
+      expect(page).to have_link("Progress")
+  
+      click_on "Progress"
+  
+      expect(current_path).to eq(athlete_path(@stace))
+    end
+  end
+end


### PR DESCRIPTION
I added an athlete show and edit page.  

A link to edit is accessible on both the athlete show page and the athlete index.  Fields are pre-populated with current athlete data and can be amended from there. 

I'm not sure if links or buttons are more appropriate but again, bigger fish to fry.  We can make it pretty and/or standard later. 